### PR TITLE
bug fix: typo in title attribute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export const remarkMdxImages: Attacher<[RemarkMdxImagesOptions?]> = ({ resolve =
       },
     ];
     if (title) {
-      attributes.push({ type: 'mdxJsxAttribute', name: 'alt', value: title });
+      attributes.push({ type: 'mdxJsxAttribute', name: 'title', value: title });
     }
     (parent as Parent).children.splice(index, 1, {
       type: 'mdxJsxTextElement',


### PR DESCRIPTION
Thank you for the plug-in 🙏.

At the moment, given the following input
```
![Very cute kittens](./kittens.png 'Meow!')
```

We won't end up with the `title` prop, like the example suggests
```jsx
import kittens from './kittens.png';

export default function MDXContent() {
  return (
    <p>
      <img alt="Very cute kittens" src={kittens} title="Meow!" /> // <- title won't exist!
    </p>
  );
}
```
Rather, we will end up with 
```js
{
  alt: "Meow!"
  src: {kittens}
}
```

This is because the plugin is overwriting the `alt` attribute with the value of `title` , instead of pushing it to a `title` attribute.
```
attributes.push({ type: 'mdxJsxAttribute', name: 'alt', value: title });
```

I assume this is a typo 😅.